### PR TITLE
Swik 575

### DIFF
--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -351,7 +351,11 @@ let self = module.exports = {
     getDeckTree: function(request, reply) {
         deckDB.getDeckTreeFromDB(request.params.id)
         .then((deckTree) => {
-            reply(deckTree);
+            if (co.isEmpty(deckTree))
+                reply(boom.notFound());
+            else{
+                reply(deckTree);
+            }
         });
     },
 

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -257,6 +257,37 @@ let self = module.exports = {
 
     },
 
+    forkDeckRevision: function(request, reply) {
+        //NOTE shall the payload and/or response be cleaned or enhanced with values?
+        deckDB.get(encodeURIComponent(request.params.id)).then((existingDeck) => {
+            let ind = existingDeck.revisions.length-1;
+            let payload = {
+                title: existingDeck.revisions[ind].title,
+                description: existingDeck.description,
+                language: existingDeck.revisions[ind].language,
+                tags: existingDeck.revisions[ind].tags,
+                license: existingDeck.license,
+                user: request.payload.user,
+                fork: true
+            };
+            //console.log(payload);
+            deckDB.replace(encodeURIComponent(request.params.id), payload).then((replaced) => {
+                if (co.isEmpty(replaced.value))
+                    throw replaced;
+                else{
+                    deckDB.get(replaced.value._id).then((newDeck) => {
+                        newDeck.revisions = [newDeck.revisions[newDeck.revisions.length-1]];
+                        reply(newDeck);
+                    });
+                }
+            }).catch((error) => {
+                request.log('error', error);
+                reply(boom.badImplementation());
+            });
+        });
+
+    },
+
     // revertDeckRevision: function(request, reply) {
     //     deckDB.revert(encodeURIComponent(request.params.id), request.payload).then((reverted) => {
     //         if (co.isEmpty(reverted))

--- a/application/database/deckDatabase.js
+++ b/application/database/deckDatabase.js
@@ -181,6 +181,9 @@ let self = module.exports = {
                 //let usageArray = existingDeck.revisions[activeRevisionIndex].usage;
                 //console.log('content_items', content_items);
                 //console.log('usageArray', usageArray);
+                if(deck.fork){
+                    usageArray = [];
+                }
 
                 const deckWithNewRevision = convertDeckWithNewRevision(deck, newRevisionId, content_items, usageArray);
                 deckWithNewRevision.timestamp = existingDeck.timestamp;
@@ -193,7 +196,7 @@ let self = module.exports = {
                     else{
                         contributors.push({'user': deck.user, 'count': 1});
                     }
-                    deckWithNewRevision.contributors = contributors;  
+                    deckWithNewRevision.contributors = contributors;
                 }
 
                 try {
@@ -670,6 +673,9 @@ function convertToNewDeck(deck){
     }
     deck.user = parseInt(deck.user);
     let contributorsArray = [{'user': deck.user, 'count': 1}];
+    if(!deck.hasOwnProperty('tags') || deck.tags === null){
+        deck.tags = [];
+    }    
     const result = {
         _id: deck._id,
         user: deck.user,
@@ -709,6 +715,9 @@ function convertToNewDeck(deck){
 function convertDeckWithNewRevision(deck, newRevisionId, content_items, usageArray) {
     let now = new Date();
     deck.user = parseInt(deck.user);
+    if(!deck.hasOwnProperty('tags') || deck.tags === null){
+        deck.tags = [];
+    }
     const result = {
         //user: deck.user,
         //deck: deck.root_deck,

--- a/application/database/deckDatabase.js
+++ b/application/database/deckDatabase.js
@@ -471,6 +471,8 @@ let self = module.exports = {
                 });
 
 
+            }).catch((err) => {
+                console.log('Deck not found');
             });
         });
     },
@@ -675,7 +677,7 @@ function convertToNewDeck(deck){
     let contributorsArray = [{'user': deck.user, 'count': 1}];
     if(!deck.hasOwnProperty('tags') || deck.tags === null){
         deck.tags = [];
-    }    
+    }
     const result = {
         _id: deck._id,
         user: deck.user,

--- a/application/routes.js
+++ b/application/routes.js
@@ -140,6 +140,24 @@ module.exports = function(server) {
     });
 
     server.route({
+        method: 'PUT',
+        path: '/deck/{id}/fork',
+        handler: handlers.forkDeckRevision,
+        config: {
+            validate: {
+                params: {
+                    id: Joi.string()
+                },
+                payload: Joi.object().keys({                    
+                    user: Joi.string().alphanum().lowercase()
+                }).requiredKeys('user'),
+            },
+            tags: ['api'],
+            description: 'Create a fork of a deck, by creating a new revision'
+        }
+    });
+
+    server.route({
         method: 'POST',
         path: '/deck/revert/{id}',
         handler: handlers.revertDeckRevision,


### PR DESCRIPTION
- Added support for fork button. Currently it creates a copy of the deck as a new revision of the deck, but erases its usage.

- Fixed issue with timeouts when getting a non-existing deck from the platform