### PR TITLE
Added routes to count slides and revisions

### DIFF
--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -484,6 +484,7 @@ let self = module.exports = {
                     }
                     else{
                         //change position of the existing slide
+                        //NOTE must also update usage
                         deckDB.insertNewContentItem(slide, slidePosition, parentID, 'slide', slideRevision+1);
                         node = {title: slide.revisions[slideRevision].title, id: slide.id+'-'+slide.revisions[slideRevision].id, type: 'slide'};
                         reply(node);
@@ -1092,6 +1093,49 @@ let self = module.exports = {
 
             return reply(result);
 
+        });
+    },
+
+    countDeckRevisions: function(request, reply){
+        deckDB.get(request.params.id.split('-')[0]).then((foundDeck) => {
+            if(!foundDeck){
+                reply(boom.notFound());
+            }
+            else{
+                reply(foundDeck.revisions.length);
+            }
+        });
+    },
+
+    countSlideRevisions: function(request, reply){
+        slideDB.get(request.params.id.split('-')[0]).then((foundSlide) => {
+            if(!foundSlide){
+                reply(boom.notFound());
+            }
+            else{
+                reply(foundSlide.revisions.length);                
+            }
+        });
+    },
+
+    countSlides: function(request, reply){
+        deckDB.get(request.params.id).then((foundDeck) => {
+            if(!foundDeck){
+                reply(boom.notFound());
+            }
+            else{
+                let activeRevision = 1;
+                if(request.params.id.split('-').length > 1){
+                    activeRevision = parseInt(request.params.id.split('-')[1]);
+                }
+                let slideCount = 0;
+                for(let i = 0; i < foundDeck.revisions[activeRevision-1].contentItems.length; i++){
+                    if(foundDeck.revisions[activeRevision-1].contentItems[i].kind === 'slide'){
+                        slideCount++;
+                    }
+                }
+                reply(slideCount);
+            }
         });
     }
 

--- a/application/database/deckDatabase.js
+++ b/application/database/deckDatabase.js
@@ -346,7 +346,10 @@ let self = module.exports = {
                 }
                 //remove reference from item to root deck, and from deck to removed item
                 let itemId = citems[position-1].ref.id;
+                //NOTE here we must also update the usage of itemID, by removing root_deck
                 col.findOneAndUpdate({_id: parseInt(itemId)}, {'$set' : {'deck' : null}});
+
+
                 citems.splice(position-1, 1);
                 existingDeck.revisions[activeRevisionId-1].contentItems = citems;
                 col.save(existingDeck);

--- a/application/database/slideDatabase.js
+++ b/application/database/slideDatabase.js
@@ -312,7 +312,7 @@ module.exports = {
               });
         });
     }
-};
+}; 
 
 function convertToNewSlide(slide) {
     let now = new Date();

--- a/application/routes.js
+++ b/application/routes.js
@@ -121,6 +121,36 @@ module.exports = function(server) {
     });
 
     server.route({
+        method: 'GET',
+        path: '/deck/{id}/revisionCount',
+        handler: handlers.countDeckRevisions,
+        config: {
+            validate: {
+                params: {
+                    id: Joi.string()
+                },
+            },
+            tags: ['api'],
+            description: 'Get total count of revisions for this deck'
+        }
+    });
+
+    server.route({
+        method: 'GET',
+        path: '/deck/{id}/slideCount',
+        handler: handlers.countSlides,
+        config: {
+            validate: {
+                params: {
+                    id: Joi.string()
+                },
+            },
+            tags: ['api'],
+            description: 'Get total count of slides for this deck'
+        }
+    });
+
+    server.route({
         method: 'POST',
         path: '/deck/new',
         handler: handlers.newDeck,
@@ -365,6 +395,21 @@ module.exports = function(server) {
             },
             tags: ['api'],
             description: 'Revert a slide to an old revision'
+        }
+    });
+
+    server.route({
+        method: 'GET',
+        path: '/slide/{id}/revisionCount',
+        handler: handlers.countSlideRevisions,
+        config: {
+            validate: {
+                params: {
+                    id: Joi.string()
+                },
+            },
+            tags: ['api'],
+            description: 'Get total count of revisions for this slide'
         }
     });
 


### PR DESCRIPTION
Added routes to count slides for a deck (deck/{id}/slideCount) and revisions of a deck/slide (deck/{id}/revisionCount and slide/{id}/revisionCount)