### PR TITLE
Swik 469 manage data sources

### DIFF
--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -188,6 +188,22 @@ let self = module.exports = {
         });
     },
 
+    saveDataSources: function(request, reply) {
+        let slideId = request.params.id;
+
+        slideDB.saveDataSources(encodeURIComponent(slideId), request.payload).then((replaced) => {
+            //console.log('updated: ', replaced);
+            if (co.isEmpty(replaced))
+                throw replaced;
+            else {
+                reply(replaced.value);
+            }
+        }).catch((error) => {
+            request.log('error', error);
+            reply(boom.badImplementation());
+        });
+    },
+
     getDeck: function(request, reply) {
         deckDB.get(encodeURIComponent(request.params.id)).then((deck) => {
             if (co.isEmpty(deck))

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -191,7 +191,7 @@ let self = module.exports = {
     saveDataSources: function(request, reply) {
         let slideId = request.params.id;
 
-        slideDB.saveDataSources(encodeURIComponent(slideId), request.payload).then((replaced) => {
+        slideDB.saveDataSources(encodeURIComponent(slideId), request.payload.dataSources).then((replaced) => {
             //console.log('updated: ', replaced);
             if (co.isEmpty(replaced))
                 throw replaced;

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -219,7 +219,6 @@ let self = module.exports = {
                                 if (contentItem.kind === 'slide') {
                                     const slideId = contentItem.ref.id;
                                     const slideRevisionId = contentItem.ref.revision;
-                                    // let promise = module.exports.getSlide({'params' : {'id' : slideId}}, (slide) => {
                                     let promise = slideDB.get(encodeURIComponent(slideId)).then((slide) => {
                                         if (slide.revisions !== undefined && slide.revisions.length > 0 && slide.revisions[0] !== null) {
                                             let slideRevision = slide.revisions.find((revision) =>  String(revision.id) ===  String(slideRevisionId));
@@ -258,7 +257,6 @@ let self = module.exports = {
                             Promise.all(arrayOfSlidePromisses).then(() => {
                                 deckRevision.dataSources = dataSources;
                                 reply(deck);
-
                             }).catch((error) => {
                                 request.log('error', error);
                                 reply(boom.badImplementation());
@@ -1193,7 +1191,7 @@ let self = module.exports = {
                 reply(boom.notFound());
             }
             else{
-                reply(foundSlide.revisions.length);                
+                reply(foundSlide.revisions.length);
             }
         });
     },

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -193,11 +193,7 @@ let self = module.exports = {
 
         slideDB.saveDataSources(encodeURIComponent(slideId), request.payload.dataSources).then((replaced) => {
             //console.log('updated: ', replaced);
-            if (co.isEmpty(replaced))
-                throw replaced;
-            else {
-                reply(replaced.value);
-            }
+            reply(replaced);
         }).catch((error) => {
             request.log('error', error);
             reply(boom.badImplementation());

--- a/application/database/slideDatabase.js
+++ b/application/database/slideDatabase.js
@@ -237,6 +237,34 @@ module.exports = {
         });
     },
 
+    saveDataSources: function(id, dataSources) {
+        let idArray = id.split('-');
+
+        return helper.connectToDatabase()
+        .then((db) => db.collection('slides'))
+        .then((col) => {
+            return col.findOne({_id: parseInt(idArray[0])})
+            .then((existingSlide) => {
+
+                let valid = false;
+                try {
+                    existingSlide.revisions[parseInt(idArray[1])-1].dataSources = dataSources;
+                    valid = slideModel(existingSlide);
+
+                    if (!valid) {
+                        return slideModel.errors;
+                    }
+
+                    col.save(existingSlide);
+                    return dataSources;
+                } catch (e) {
+                    console.log('validation failed', e);
+                }
+                return;
+            });
+        });
+    },
+
     rename: function(slide_id, newName){
         let slideId = slide_id.split('-')[0];
         return helper.connectToDatabase()

--- a/application/database/slideDatabase.js
+++ b/application/database/slideDatabase.js
@@ -248,7 +248,11 @@ module.exports = {
 
                 let valid = false;
                 try {
-                    existingSlide.revisions[parseInt(idArray[1])-1].dataSources = dataSources;
+                    const revisionId = idArray[1];
+                    let revision = (revisionId !== undefined) ? existingSlide.revisions.find((revision) => String(revision.id) === String(revisionId)) : undefined;
+                    if (revision !== undefined) {
+                        revision.dataSources = dataSources;
+                    }
                     valid = slideModel(existingSlide);
 
                     if (!valid) {

--- a/application/database/slideDatabase.js
+++ b/application/database/slideDatabase.js
@@ -245,24 +245,17 @@ module.exports = {
         .then((col) => {
             return col.findOne({_id: parseInt(idArray[0])})
             .then((existingSlide) => {
-
-                // let valid = false;
                 try {
                     const revisionId = idArray[1];
                     let revision = (revisionId !== undefined) ? existingSlide.revisions.find((revision) => String(revision.id) === String(revisionId)) : undefined;
                     if (revision !== undefined) {
                         revision.dataSources = dataSources;
                     }
-                    // valid = slideModel(existingSlide);
-                    //
-                    // if (!valid) {
-                    //     return slideModel.errors;
-                    // }
 
                     col.save(existingSlide);
                     return dataSources;
                 } catch (e) {
-                    console.log('validation failed', e);
+                    console.log('saveDataSources failed', e);
                 }
                 return;
             });
@@ -344,7 +337,7 @@ module.exports = {
               });
         });
     }
-}; 
+};
 
 function convertToNewSlide(slide) {
     let now = new Date();

--- a/application/database/slideDatabase.js
+++ b/application/database/slideDatabase.js
@@ -246,18 +246,18 @@ module.exports = {
             return col.findOne({_id: parseInt(idArray[0])})
             .then((existingSlide) => {
 
-                let valid = false;
+                // let valid = false;
                 try {
                     const revisionId = idArray[1];
                     let revision = (revisionId !== undefined) ? existingSlide.revisions.find((revision) => String(revision.id) === String(revisionId)) : undefined;
                     if (revision !== undefined) {
                         revision.dataSources = dataSources;
                     }
-                    valid = slideModel(existingSlide);
-
-                    if (!valid) {
-                        return slideModel.errors;
-                    }
+                    // valid = slideModel(existingSlide);
+                    //
+                    // if (!valid) {
+                    //     return slideModel.errors;
+                    // }
 
                     col.save(existingSlide);
                     return dataSources;

--- a/application/models/slide.js
+++ b/application/models/slide.js
@@ -25,6 +25,30 @@ const contributor = {
     },
     required: ['user']
 };
+const dataSource = {
+    type: 'object',
+    properties: {
+        type: {
+            type: 'string'
+        },
+        title: {
+            type: 'string'
+        },
+        url: {
+            type: 'string'
+        },
+        comment: {
+            type: 'string'
+        },
+        authors: {
+            type: 'string'
+        },
+        year: {
+            type: 'string'
+        }
+    },
+    required: ['type','title']
+};
 const slideRevision = {
     type: 'object',
     properties: {
@@ -90,14 +114,7 @@ const slideRevision = {
         },
         dataSources: {
             type: 'array',
-            items: {
-                type: 'string',
-                title: 'string',
-                url: 'string',
-                comment: 'string',
-                authors: 'string',
-                year: 'string'
-            }
+            items: dataSource
         },
         usage: {
             type: 'array',

--- a/application/models/slide.js
+++ b/application/models/slide.js
@@ -90,7 +90,14 @@ const slideRevision = {
         },
         dataSources: {
             type: 'array',
-            items: objectid
+            items: {
+                type: 'string',
+                title: 'string',
+                url: 'string',
+                comment: 'string',
+                authors: 'string',
+                year: 'string'
+            }
         },
         usage: {
             type: 'array',

--- a/application/routes.js
+++ b/application/routes.js
@@ -368,6 +368,31 @@ module.exports = function(server) {
         }
     });
 
+    server.route({
+        method: 'PUT',
+        path: '/slide/datasources/{id}',
+        handler: handlers.saveDataSources,
+        config: {
+            validate: {
+                params: {
+                    id: Joi.string()
+                },
+                payload: Joi.object().keys({
+                    datasources: Joi.array().items({
+                        type: Joi.string(),
+                        title: Joi.string(),
+                        url: Joi.string(),
+                        comment: Joi.string(),
+                        authors: Joi.string(),
+                        year: Joi.string()
+                    }).default([])
+                }).requiredKeys('datasources'),
+            },
+            tags: ['api'],
+            description: 'Replace slide data sources'
+        }
+    });
+
     //------------decktree APIs----------------
     server.route({
         method: 'GET',

--- a/application/routes.js
+++ b/application/routes.js
@@ -378,15 +378,15 @@ module.exports = function(server) {
                     id: Joi.string()
                 },
                 payload: Joi.object().keys({
-                    datasources: Joi.array().items({
+                    dataSources: Joi.array().items(Joi.object().keys({
                         type: Joi.string(),
                         title: Joi.string(),
-                        url: Joi.string(),
-                        comment: Joi.string(),
-                        authors: Joi.string(),
-                        year: Joi.string()
-                    }).default([])
-                }).requiredKeys('datasources'),
+                        url: Joi.string().allow(''),
+                        comment: Joi.string().allow(''),
+                        authors: Joi.string().allow(''),
+                        year: Joi.string().allow('')
+                    })).default([])
+                }).requiredKeys('dataSources'),
             },
             tags: ['api'],
             description: 'Replace slide data sources'


### PR DESCRIPTION
Functionality for reading and saving data sources is implemented.
-Data model for slide revisions is modified to include data sources object.
-A new route (and handler function) is added for saving data sources of a slide.
-Deck data sources are collected from its slides, after getting the deck from the database. This slightly prolongs execution of the getDeck function, so if we want to avoid this, we can create a new route for getting the deck data sources.