### PR TITLE
Swik 469 manage data sources

### DIFF
--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -246,8 +246,8 @@ let self = module.exports = {
                             promise.then((deckTree) => {
                                 deckTree.children.forEach((child) => {
                                     let idArray = child.id.split('-');
-                                    const newSlideId = idArray[0];
-                                    const newSlideRevisionId = idArray[1];
+                                    const newSlideId = parseInt(idArray[0]);
+                                    const newSlideRevisionId = parseInt(idArray[1]);
                                     if (!(newSlideId in slideRevisionsMap)) {
                                         arrayOfSlideIds.push(newSlideId);
                                         slideRevisionsMap[newSlideId] = newSlideRevisionId;

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -291,7 +291,13 @@ let self = module.exports = {
 
                                     deckRevision.dataSources = dataSources;
                                     reply(deck);
+                                }).catch((error) => {
+                                    console.log('error', error);
+                                    reply(deck);
                                 });
+                            }).catch((error) => {
+                                console.log('error', error);
+                                reply(deck);
                             });
                         } else {
                             deckRevision.dataSources = [];

--- a/application/database/slideDatabase.js
+++ b/application/database/slideDatabase.js
@@ -54,10 +54,7 @@ module.exports = {
     getSelected: function(identifiers) {
         return helper.connectToDatabase()
         .then((db) => db.collection('slides'))
-        .then((col) => col.find({ _id:  { $in : identifiers.selectedIDs.map(function(id) {
-            return oid(id);
-        })
-    }}))
+        .then((col) => col.find({ _id:  { $in : identifiers.selectedIDs }}))
     .then((stream) => stream.sort({timestamp: -1}))
     .then((stream) => stream.toArray());
     },


### PR DESCRIPTION
This is the correction of the way that deck data sources are being fetched. It fixes the issue with data sources belonging to sub-decks.
Deck data sources are the sum of all unique data sources in each slide.
To get all slide ids, first all slides from the contentItem (already a part of the deck object) are collected.
If there are one or more sub-decks, the getFlatSlidesFromDB function is used to get all slides from the database and then slides which belong to sub-decks are added.
Function getSelected is used to get slides with specified ids and then data sources are collected from each of them.
