### PR TITLE
SWIK-1061 exchange image-service with file-service for slide thumbnails

### DIFF
--- a/application/configs/microservices.js
+++ b/application/configs/microservices.js
@@ -4,10 +4,6 @@ const co = require('../common');
 
 module.exports = {
     'file': {
-        uri: (!co.isEmpty(process.env.SERVICE_URL_FILE)) ? process.env.SERVICE_URL_FILE : 'http://fileservice',
-        shareVolume: '/data/files'
-    },
-    'image': {
-        uri: (!co.isEmpty(process.env.SERVICE_URL_IMAGE)) ? process.env.SERVICE_URL_IMAGE : 'http://imageservice',
+        uri: (!co.isEmpty(process.env.SERVICE_URL_FILE)) ? process.env.SERVICE_URL_FILE : 'http://fileservice'
     }
 };

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -69,13 +69,13 @@ let self = module.exports = {
                 throw inserted;
             else{
                 //deckDB.insertNewContentItem(inserted.ops[0], request.payload.position, request.payload.root_deck, 'slide');
-                let content = inserted.ops[0].revisions[0].content, user = request.payload.user, slideId = inserted.ops[0]._id+'-'+1;
+                let content = inserted.ops[0].revisions[0].content, slideId = inserted.ops[0]._id+'-'+1;
                 if(content === ''){
                     content = '<h2>'+inserted.ops[0].revisions[0].title+'</h2>';
                     //for now we use hardcoded template for new slides
                     content = slidetemplate;
                 }
-                createThumbnail(content, slideId, user);
+                createThumbnail(content, slideId);
 
                 reply(co.rewriteID(inserted.ops[0]));
             }
@@ -123,13 +123,13 @@ let self = module.exports = {
 
                             deckDB.updateContentItem(newSlide, '', request.payload.root_deck, 'slide');
                             newSlide.revisions = [newSlide.revisions[newSlide.revisions.length-1]];
-                            let content = newSlide.revisions[0].content, user = request.payload.user, newSlideId = newSlide._id+'-'+newSlide.revisions[0].id;
+                            let content = newSlide.revisions[0].content, newSlideId = newSlide._id+'-'+newSlide.revisions[0].id;
                             if(content === ''){
                                 content = '<h2>'+newSlide.revisions[0].title+'</h2>';
                                 //for now we use hardcoded template for new slides
                                 content = slidetemplate;
                             }
-                            createThumbnail(content, newSlideId, user);
+                            createThumbnail(content, newSlideId);
                             if(changeset && changeset.hasOwnProperty('target_deck')){
                                 changeset.new_revisions.push(newSlideId);
                                 newSlide.changeset = changeset;
@@ -343,14 +343,14 @@ let self = module.exports = {
                         //   deckDB.insertNewContentItem(inserted.ops[0], request.payload.position, request.payload.root_deck, 'deck');
                         reply(co.rewriteID(inserted.ops[0]));
                     });
-                    let content = newSlide.content, user = inserted.ops[0].user, slideId = insertedSlide.ops[0].id+'-'+1;
+                    let content = newSlide.content, slideId = insertedSlide.ops[0].id+'-'+1;
                     if(content === ''){
                         content = '<h2>'+newSlide.title+'</h2>';
                         //for now we use hardcoded template for new slides
                         content = slidetemplate;
                     }
 
-                    createThumbnail(content, slideId, user);
+                    createThumbnail(content, slideId);
                 });
                 //check if a root deck is defined, if yes, update its content items to reflect the new sub-deck
 
@@ -1506,19 +1506,15 @@ let self = module.exports = {
 
 };
 
-function createThumbnail(slideContent, slideId, user) {
+function createThumbnail(slideContent, slideId) {
     let rp = require('request-promise-native');
     let he = require('he');
 
     let encodedContent = he.encode(slideContent, {allowUnsafeSymbols: true});
 
     rp.post({
-        uri: Microservices.image.uri + '/thumbnail',
-        body: JSON.stringify({
-            userID: String(user),
-            html: encodedContent,
-            filename: slideId
-        }),
+        uri: Microservices.file.uri + '/slideThumbnail/' + slideId,
+        body: encodedContent
     }).catch((e) => {
         console.log('problem with request thumb: ' + e.message);
     });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,4 @@ deckservice:
     - LETSENCRYPT_HOST=deckservice.experimental.slidewiki.org
     - LETSENCRYPT_EMAIL=meissner@informatik.uni-leipzig.de
     - SERVICE_URL_FILE=https://fileservice.experimental.slidewiki.org
-    - SERVICE_URL_IMAGE=https://imageservice.experimental.slidewiki.org
     - DATABASE_URL=mongodb # use a url or the name, defined in the docker-compose file


### PR DESCRIPTION
I've removed the image-service from the docker-compose and microservices.config file, as the service will be discarded (stopped & removed). I've changed the thumbnail creation to match the new API of the file-service.

I haven't tested the changes yet, as I wait for approval of https://github.com/slidewiki/file-service/pull/2 first. I'll comment this PR again as soon as the other PR has been merged.