### PR TITLE
Bring server down (crash) once there's no way to reconnect to mongo

### DIFF
--- a/application/database/helper.js
+++ b/application/database/helper.js
@@ -117,14 +117,14 @@ let self = module.exports = {
                 if (db.s.databaseName !== dbname)
                     throw new 'Wrong Database!';
 
-                // log connection status and bring down the service once db is done for
+                // log connection status and reset connection once reconnect fails
                 db.on('close', (err) => {
                     if (err) {
                         console.warn(err.message);
                     }
                 });
-                db.on('reconnect', (err) => {
-                    console.warn(err ? `reconnected to ${err.s.host}:${err.s.port}`: 'reconnected to mongodb');
+                db.on('reconnect', (payload) => {
+                    console.warn(payload ? `reconnected to ${payload.s.host}:${payload.s.port}`: 'reconnected to mongodb');
                 });
                 // HACK This is an undocumented event name, but it's there and it works
                 // best solution so far, and even if it's removed in the future, it will not break anything else


### PR DESCRIPTION
This changes the database helper connection logic to:
1. monitor when a connection is lost and when reconnection occurs
1. detect when reconnect retries are exhausted, hence discarding the connection
1. immediately exit when no connection is established on *any* first attempt

Since deck-service always tries to connect to database before starting the http server in order to ensure the indexes are there, if there is no mongo running when the service is brought up, it will also crash immediately.

After first connect is successful, if at any point mongodb is unreachable, the service will try to reconnect a few times, then discard the connection object. Next time there is a request coming in, it will try to get a connection, and if it fails again, it will crash.

After this is merged, a PR for the https://github.com/slidewiki/microservice-template should also be created, so that all other services may pull in this enhancement.