### PR TITLE
Stop augmenting deck featured, recent responses with user info

### DIFF
--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -21,7 +21,6 @@ const boom = require('boom'),
 // TODO remove this from here after we've refactored all database-specific code into slide/deck database js files
 const ChangeLog = require('../lib/ChangeLog');
 
-const userService = require('../services/user');
 const tagService = require('../services/tag');
 const fileService = require('../services/file');
 
@@ -1655,15 +1654,12 @@ let self = module.exports = {
         deckDB.getAllRecent(limit, offset).then( (recentDecks) => {
             if(!recentDecks) return reply([]);
 
-            let userIds = new Set(), countForksIds = new Set();
-
-            // collect user ids and deck ids to count forks needed
+            let countForksIds = new Set();
+            // collect deck ids to count forks needed
             recentDecks.forEach( (deck) => {
-                userIds.add(deck.user);
                 countForksIds.add(deck._id);
             });
-
-            // count deck forks for the abouve deck ids
+            // count deck forks for the above deck ids
             let forkCounts = {};
             let forkCountsPromise = deckDB.countManyDeckForks([...countForksIds]).then( (forkCountsInfo) => {
                 forkCountsInfo.forEach( (forkCount) => {
@@ -1671,15 +1667,7 @@ let self = module.exports = {
                 });
             });
 
-            // fetch usernames for user ids needed
-            let usernames = {};
-            let userPromise = userService.fetchUserInfo([...userIds]).then( (userInfo) => {
-                userInfo.forEach( (u) => {
-                    usernames[u.id] = u.username;
-                });
-            });
-
-            return Promise.all([userPromise, forkCountsPromise]).then( () => {
+            return forkCountsPromise.then( () => {
 
                 recentDecks = recentDecks.map( (deck) => {
 
@@ -1695,7 +1683,6 @@ let self = module.exports = {
                         title: activeRevision.title,
                         description: deck.description,
                         user: deck.user,
-                        username: (usernames[deck.user]) ? usernames[deck.user] : 'Unknown user',
                         active: deck.active,
                         countRevisions: deck.revisions.length,
                         timestamp: deck.timestamp,
@@ -1728,15 +1715,12 @@ let self = module.exports = {
         deckDB.getAllFeatured(limit, offset).then( (featuredDecks) => {
             if(!featuredDecks) return reply([]);
 
-            let userIds = new Set(), countForksIds = new Set();
-
-            // collect user ids and deck ids to count forks needed
+            let countForksIds = new Set();
+            // collect deck ids to count forks needed
             featuredDecks.forEach( (deck) => {
-                userIds.add(deck.user);
                 countForksIds.add(deck._id);
             });
-
-            // count deck forks for the abouve deck ids
+            // count deck forks for the above deck ids
             let forkCounts = {};
             let forkCountsPromise = deckDB.countManyDeckForks([...countForksIds]).then( (forkCountsInfo) => {
                 forkCountsInfo.forEach( (forkCount) => {
@@ -1744,15 +1728,7 @@ let self = module.exports = {
                 });
             });
 
-            // fetch usernames for user ids needed
-            let usernames = {};
-            let userPromise = userService.fetchUserInfo([...userIds]).then( (userInfo) => {
-                userInfo.forEach( (u) => {
-                    usernames[u.id] = u.username;
-                });
-            });
-
-            return Promise.all([userPromise, forkCountsPromise]).then( () => {
+            return forkCountsPromise.then( () => {
                 featuredDecks = featuredDecks.map( (deck) => {
 
                     // get active revision
@@ -1767,7 +1743,6 @@ let self = module.exports = {
                         title: activeRevision.title,
                         description: deck.description,
                         user: deck.user,
-                        username: (usernames[deck.user]) ? usernames[deck.user] : 'Unknown user',
                         active: deck.active,
                         countRevisions: deck.revisions.length,
                         timestamp: deck.timestamp,

--- a/application/controllers/slides.js
+++ b/application/controllers/slides.js
@@ -6,8 +6,6 @@ const boom = require('boom');
 const slideDB = require('../database/slideDatabase');
 const contributorsDB = require('../database/contributors');
 
-const userService = require('../services/user');
-
 let self = module.exports = {
 
     getContributors: function(request, reply) {


### PR DESCRIPTION
This removes an unnecessary dependency of the featured / recent responses to the user service. The client will only receive the creator user id and can handle it in whatever way seems fit. 

This can only be merged *after* https://github.com/slidewiki/slidewiki-platform/pull/956 is merged.